### PR TITLE
:recycle: Refactor: Store 조회 N+1 문제 개선 및 태그 조회 로직 최적화

### DIFF
--- a/src/main/java/com/umc9th/bizscan/domain/store/repository/StoreTagRepository.java
+++ b/src/main/java/com/umc9th/bizscan/domain/store/repository/StoreTagRepository.java
@@ -9,7 +9,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface StoreTagRepository extends JpaRepository<StoreTag, Long> {
 
-  @Query("""
+  @Query(
+      """
       select st
       from StoreTag st
       join fetch st.tag
@@ -17,7 +18,8 @@ public interface StoreTagRepository extends JpaRepository<StoreTag, Long> {
       """)
   List<StoreTag> findAllByStoreInFetchTag(@Param("stores") List<Store> stores);
 
-  @Query("""
+  @Query(
+      """
       select st
       from StoreTag st
       join fetch st.tag

--- a/src/main/java/com/umc9th/bizscan/domain/store/repository/StoreTagRepository.java
+++ b/src/main/java/com/umc9th/bizscan/domain/store/repository/StoreTagRepository.java
@@ -4,10 +4,26 @@ import com.umc9th.bizscan.domain.store.entity.Store;
 import com.umc9th.bizscan.domain.store.entity.StoreTag;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StoreTagRepository extends JpaRepository<StoreTag, Long> {
 
-  List<StoreTag> findAllByStore(Store store);
+  @Query("""
+      select st
+      from StoreTag st
+      join fetch st.tag
+      where st.store in :stores
+      """)
+  List<StoreTag> findAllByStoreInFetchTag(@Param("stores") List<Store> stores);
+
+  @Query("""
+      select st
+      from StoreTag st
+      join fetch st.tag
+      where st.store = :store
+      """)
+  List<StoreTag> findAllByStoreFetchTag(@Param("store") Store store);
 
   void deleteAllByStore_Id(Long storeId);
 }

--- a/src/main/java/com/umc9th/bizscan/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/umc9th/bizscan/domain/store/service/StoreServiceImpl.java
@@ -86,7 +86,7 @@ public class StoreServiceImpl implements StoreService {
           new GeoPoint(
               new BigDecimal(addressInfo.getY()), // 위도
               new BigDecimal(addressInfo.getX()) // 경도
-          );
+              );
 
     } catch (Exception e) {
       log.warn(
@@ -180,8 +180,10 @@ public class StoreServiceImpl implements StoreService {
                     Collectors.mapping(StoreTag::getTag, Collectors.toList())));
 
     return stores.stream()
-        .map(store -> storeMapper.toCreateResponse(store,
-            tagsByStoreId.getOrDefault(store.getId(), List.of())))
+        .map(
+            store ->
+                storeMapper.toCreateResponse(
+                    store, tagsByStoreId.getOrDefault(store.getId(), List.of())))
         .toList();
   }
 
@@ -200,9 +202,7 @@ public class StoreServiceImpl implements StoreService {
                 });
 
     List<Tag> tags =
-        storeTagRepository.findAllByStoreFetchTag(store).stream()
-            .map(StoreTag::getTag)
-            .toList();
+        storeTagRepository.findAllByStoreFetchTag(store).stream().map(StoreTag::getTag).toList();
 
     return storeMapper.toCreateResponse(store, tags);
   }

--- a/src/main/java/com/umc9th/bizscan/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/umc9th/bizscan/domain/store/service/StoreServiceImpl.java
@@ -86,7 +86,7 @@ public class StoreServiceImpl implements StoreService {
           new GeoPoint(
               new BigDecimal(addressInfo.getY()), // 위도
               new BigDecimal(addressInfo.getX()) // 경도
-              );
+          );
 
     } catch (Exception e) {
       log.warn(
@@ -166,14 +166,22 @@ public class StoreServiceImpl implements StoreService {
     List<Store> stores = storeRepository.findAll();
     log.info("Stores loaded. count={}", stores.size());
 
-    return stores.stream()
-        .map(
-            store -> {
-              List<Tag> tags =
-                  storeTagRepository.findAllByStore(store).stream().map(StoreTag::getTag).toList();
+    if (stores.isEmpty()) {
+      return List.of();
+    }
 
-              return storeMapper.toCreateResponse(store, tags);
-            })
+    List<StoreTag> storeTags = storeTagRepository.findAllByStoreInFetchTag(stores);
+
+    Map<Long, List<Tag>> tagsByStoreId =
+        storeTags.stream()
+            .collect(
+                Collectors.groupingBy(
+                    st -> st.getStore().getId(),
+                    Collectors.mapping(StoreTag::getTag, Collectors.toList())));
+
+    return stores.stream()
+        .map(store -> storeMapper.toCreateResponse(store,
+            tagsByStoreId.getOrDefault(store.getId(), List.of())))
         .toList();
   }
 
@@ -192,7 +200,9 @@ public class StoreServiceImpl implements StoreService {
                 });
 
     List<Tag> tags =
-        storeTagRepository.findAllByStore(store).stream().map(StoreTag::getTag).toList();
+        storeTagRepository.findAllByStoreFetchTag(store).stream()
+            .map(StoreTag::getTag)
+            .toList();
 
     return storeMapper.toCreateResponse(store, tags);
   }


### PR DESCRIPTION
## 💡 관련 이슈
- Close #43 

## 🛠 작업 내용
- 가게 전체 조회 시 발생하던 N+1 쿼리 문제 개선
- StoreTag와 Tag를 Fetch Join 기반 단일 쿼리로 조회하도록 Repository 로직 리팩토링
- 조회된 태그를 Store ID 기준으로 그룹핑하여 응답 매핑 로직 최적화