### PR TITLE
:recycle: Refactor: docker-compose datasource 환경변수 구조 정리 및 RDS 전환 준비

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,9 +6,9 @@ services:
       - "8080:8080"
     environment:
       SPRING_PROFILES_ACTIVE: ${PROFILE:-dev}
-      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/${DB_NAME}
-      SPRING_DATASOURCE_USERNAME: ${DB_USER}
-      SPRING_DATASOURCE_PASSWORD: ${DB_PASS}
+      DB_URL: ${DB_URL}
+      DB_USER: ${DB_USER}
+      DB_PW: ${DB_PW}
       TZ: Asia/Seoul
       NAVER_AD_API_KEY: ${NAVER_AD_API_KEY}
       NAVER_AD_SECRET_KEY: ${NAVER_AD_SECRET_KEY}
@@ -16,10 +16,8 @@ services:
       KAKAO_REST_API_KEY: ${KAKAO_REST_API_KEY}
       KAKAO_API_KEY: ${KAKAO_API_KEY}
       JWT_SECRET: ${JWT_SECRET}
-#      REDIS_PASS: ${REDIS_PASS}
+    #      REDIS_PASS: ${REDIS_PASS}
     depends_on:
-      mysql:
-        condition: service_healthy
       redis:
         condition: service_healthy
     networks:
@@ -31,10 +29,10 @@ services:
     expose:
       - "3306"
     environment:
-      MYSQL_DATABASE: ${DB_NAME}
-      MYSQL_USER: ${DB_USER}
-      MYSQL_PASSWORD: ${DB_PASS}
-      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASS}
+      MYSQL_DATABASE: ${LOCAL_DB_NAME}
+      MYSQL_USER: ${LOCAL_DB_USER}
+      MYSQL_PASSWORD: ${LOCAL_DB_PASS}
+      MYSQL_ROOT_PASSWORD: ${LOCAL_DB_ROOT_PASS}
       TZ: Asia/Seoul
     volumes:
       - mysql-data:/var/lib/mysql
@@ -55,7 +53,7 @@ services:
       - "6379"
     environment:
       TZ: Asia/Seoul
-#      REDIS_PASS: ${REDIS_PASS}
+    #      REDIS_PASS: ${REDIS_PASS}
     command: >
       redis-server
       --maxmemory 256mb


### PR DESCRIPTION
## 💡 관련 이슈
- Close #74 

## 🛠 작업 내용
- Spring Boot datasource를 환경변수 기반으로 통일
- docker-compose에서 SPRING_DATASOURCE_* 제거
- DB_URL, DB_USER, DB_PW 기반 RDS 연결 구조 적용
- 로컬 MySQL 컨테이너 환경변수 LOCAL_DB_*로 분리
- RDS 전환 기간 동안 MySQL 컨테이너는 유지
- app 서비스의 mysql depends_on 제거 (RDS 사용 기준)