### PR TITLE
:recycle: Refactor: MySQL 컨테이너 제거 및 RDS-only 구조로 전환

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,28 +24,6 @@ services:
       - bizscan-network
     restart: unless-stopped
 
-  mysql:
-    image: mysql:8.0
-    expose:
-      - "3306"
-    environment:
-      MYSQL_DATABASE: ${LOCAL_DB_NAME}
-      MYSQL_USER: ${LOCAL_DB_USER}
-      MYSQL_PASSWORD: ${LOCAL_DB_PASS}
-      MYSQL_ROOT_PASSWORD: ${LOCAL_DB_ROOT_PASS}
-      TZ: Asia/Seoul
-    volumes:
-      - mysql-data:/var/lib/mysql
-    networks:
-      - bizscan-network
-    restart: unless-stopped
-    healthcheck:
-      test: [ "CMD-SHELL", "mysqladmin ping -h localhost -u root -p$$MYSQL_ROOT_PASSWORD | grep 'mysqld is alive'" ]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 20s
-
   redis:
     image: redis:7-alpine
     container_name: redis
@@ -89,5 +67,4 @@ networks:
     driver: bridge
 
 volumes:
-  mysql-data:
   redis-data:


### PR DESCRIPTION
## 💡 관련 이슈
- Close #76 

## 🛠 작업 내용
- docker-compose.yml에서 mysql 서비스 삭제
- mysql-data 볼륨 제거