### PR TITLE
🐛 !HOTFIX: relatedSwotType DB 미저장

### DIFF
--- a/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/converter/ActionPlanConverter.java
+++ b/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/converter/ActionPlanConverter.java
@@ -17,7 +17,7 @@ public class ActionPlanConverter {
         .aiRefId(dto.id())
         .title(dto.title())
         .reason(dto.final_reason())
-        .relatedSwot(swotType)
+        //        .relatedSwot(swotType)
         .build();
   }
 


### PR DESCRIPTION
## 💡 관련 이슈
- Close #80 

## 🛠 작업 내용
- AI가 잘못된 Enum 전달 시 DB 저장 오류 발생 (500)
- 로직 리팩토링 전까지 저장 안하도록 수정 