### PR TITLE
🐛 [FIX] RelatedSwotType Enum 생성 로직 변경

### DIFF
--- a/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/converter/ActionPlanConverter.java
+++ b/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/converter/ActionPlanConverter.java
@@ -17,7 +17,7 @@ public class ActionPlanConverter {
         .aiRefId(dto.id())
         .title(dto.title())
         .reason(dto.final_reason())
-        //        .relatedSwot(swotType)
+        .relatedSwot(swotType)
         .build();
   }
 

--- a/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/enums/RelatedSwotType.java
+++ b/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/enums/RelatedSwotType.java
@@ -1,8 +1,29 @@
 package com.umc9th.bizscan.domain.aiAnalysis.enums;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 public enum RelatedSwotType {
   SO,
   ST,
   WO,
-  WT
+  WT,
+  UNDEFINED;
+
+  public static RelatedSwotType from(List<String> swotList) {
+    if (swotList == null || swotList.size() < 2) {
+      return null;
+    }
+
+    // 대문자 변환 및 Set으로 변환
+    Set<String> set = swotList.stream().map(String::toUpperCase).collect(Collectors.toSet());
+
+    if (set.contains("S") && set.contains("O")) return SO;
+    if (set.contains("S") && set.contains("T")) return ST;
+    if (set.contains("W") && set.contains("O")) return WO;
+    if (set.contains("W") && set.contains("T")) return WT;
+
+    return UNDEFINED;
+  }
 }

--- a/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/service/CallbackService.java
+++ b/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/service/CallbackService.java
@@ -97,8 +97,7 @@ public class CallbackService {
     for (ActionPlanCallbackReqDTO.FinalSelect selection :
         request.result().finalSelect().selections()) {
       // Enum 변환
-      //      RelatedSwotType swotType = toRelatedSwotType(selection.related_swot());
-      RelatedSwotType swotType = RelatedSwotType.ST;
+      RelatedSwotType swotType = RelatedSwotType.from(selection.related_swot());
 
       // ActionPlan 생성 및 저장
       ActionPlan actionPlan =
@@ -178,15 +177,6 @@ public class CallbackService {
   }
 
   // Util
-  private RelatedSwotType toRelatedSwotType(List<String> swotList) {
-    if (swotList == null || swotList.size() < 2) {
-      return null;
-    }
-    // ["S", "O"] -> "SO"로 합친 후 Enum 변환
-    String combined = String.join("", swotList).toUpperCase();
-    return RelatedSwotType.valueOf(combined);
-  }
-
   private TagType toTagType(int index) {
     return switch (index) {
       case 0 -> TagType.GOAL;


### PR DESCRIPTION
## 💡 관련 이슈
- Close #85 

## 🛠 작업 내용
- toRelatedSwotType 메소드 대신 RelatedSwotType .from 사용
- 잘못된 SWOT 조합일 경우 UNDEFINED 사용