### PR TITLE
:rocket: Deploy: Redis 기반 토큰 관리 및 JWT 인증 구조 개선 (블랙리스트 + 화이트리스트 적용)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - "6379"
     environment:
       TZ: Asia/Seoul
-    #      REDIS_PASS: ${REDIS_PASS}
     command: >
       redis-server
       --maxmemory 256mb

--- a/src/main/java/com/umc9th/bizscan/global/security/config/RedisConfig.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/config/RedisConfig.java
@@ -16,10 +16,11 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableRedisRepositories
 @Configuration
 public class RedisConfig {
-  @Value("${spring.data.redis.host}")
+
+  @Value("${spring.data.redis.host:localhost}")
   private String redisHost;
 
-  @Value("${spring.data.redis.port}")
+  @Value("${spring.data.redis.port:6379}")
   private int redisPort;
 
   @Bean

--- a/src/main/java/com/umc9th/bizscan/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/config/SecurityConfig.java
@@ -14,13 +14,15 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
   @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http,
-      JwtAuthenticationFilter jwtAuthenticationFilter, JwtExceptionFilter jwtExceptionFilter)
+  public SecurityFilterChain filterChain(
+      HttpSecurity http,
+      JwtAuthenticationFilter jwtAuthenticationFilter,
+      JwtExceptionFilter jwtExceptionFilter)
       throws Exception {
     http.csrf(csrf -> csrf.disable())
         .authorizeHttpRequests(
             auth -> auth.anyRequest().permitAll() // TODO : 추후 권한 설정
-        )
+            )
         .formLogin(form -> form.disable());
 
     http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/umc9th/bizscan/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/config/SecurityConfig.java
@@ -1,22 +1,30 @@
 package com.umc9th.bizscan.global.security.config;
 
+import com.umc9th.bizscan.global.security.filter.JwtAuthenticationFilter;
+import com.umc9th.bizscan.global.security.filter.JwtExceptionFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 public class SecurityConfig {
 
   @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+  public SecurityFilterChain filterChain(HttpSecurity http,
+      JwtAuthenticationFilter jwtAuthenticationFilter, JwtExceptionFilter jwtExceptionFilter)
+      throws Exception {
     http.csrf(csrf -> csrf.disable())
         .authorizeHttpRequests(
             auth -> auth.anyRequest().permitAll() // TODO : 추후 권한 설정
-            )
+        )
         .formLogin(form -> form.disable());
+
+    http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+    http.addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
 
     return http.build();
   }

--- a/src/main/java/com/umc9th/bizscan/global/security/controller/TokenApiController.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/controller/TokenApiController.java
@@ -16,7 +16,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @Tag(name = "Token API", description = "JWT 토큰 관련 API")
@@ -67,8 +74,11 @@ public class TokenApiController {
   @Operation(summary = "로그아웃", description = "사용자를 로그아웃 처리합니다.")
   @PostMapping("/logout")
   public ApiResponse<Void> logout(
-      @AuthenticationPrincipal User user, HttpServletResponse response) {
-    tokenService.logout(user.getUsername());
+      @AuthenticationPrincipal User user,
+      @RequestHeader(value = "Authorization", required = false) String authorization,
+      HttpServletResponse response) {
+
+    tokenService.logout(user.getUsername(), authorization);
 
     // RefreshToken Cookie 삭제
     Cookie deleteCookie = new Cookie("refreshToken", null);

--- a/src/main/java/com/umc9th/bizscan/global/security/exception/JwtAuthenticationException.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/exception/JwtAuthenticationException.java
@@ -3,6 +3,7 @@ package com.umc9th.bizscan.global.security.exception;
 import org.springframework.security.core.AuthenticationException;
 
 public class JwtAuthenticationException extends AuthenticationException {
+
   public static final AuthenticationException UNAUTHORIZED_LOGIN_DATA =
       new JwtAuthenticationException(
           SecurityErrorStatus.AUTH_UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR);
@@ -21,6 +22,9 @@ public class JwtAuthenticationException extends AuthenticationException {
       new JwtAuthenticationException(SecurityErrorStatus.AUTH_IS_NULL);
   public static final AuthenticationException TOKEN_IS_EXPIRED =
       new JwtAuthenticationException(SecurityErrorStatus.AUTH_TOKEN_HAS_EXPIRED);
+
+  public static final AuthenticationException LOGGED_OUT =
+      new JwtAuthenticationException(SecurityErrorStatus.AUTH_LOGGED_OUT_TOKEN);
 
   public JwtAuthenticationException(SecurityErrorStatus errorStatus) {
     super(errorStatus.name());

--- a/src/main/java/com/umc9th/bizscan/global/security/exception/SecurityErrorStatus.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/exception/SecurityErrorStatus.java
@@ -21,7 +21,8 @@ public enum SecurityErrorStatus implements BaseErrorCode {
   AUTH_UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR(HttpStatus.BAD_REQUEST, "4358", "로그인이 필요없는 API입니다."),
   AUTH_ASSIGNABLE_PARAMETER(HttpStatus.BAD_REQUEST, "4359", "인증타입이 잘못되어 할당이 불가능합니다."),
   AUTH_INVALID_ROLE(HttpStatus.FORBIDDEN, "4360", "유효하지 않은 역할(Role)입니다."),
-  AUTH_WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "4361", "패스워드가 잘못되었습니다.");
+  AUTH_WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "4361", "패스워드가 잘못되었습니다."),
+  AUTH_LOGGED_OUT_TOKEN(HttpStatus.UNAUTHORIZED, "4362", "로그아웃된 토큰입니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/umc9th/bizscan/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/filter/JwtAuthenticationFilter.java
@@ -48,8 +48,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
           CustomErrorSend.handleException(
               response,
               SecurityErrorStatus.AUTH_LOGGED_OUT_TOKEN,
-              SecurityErrorStatus.AUTH_LOGGED_OUT_TOKEN.name()
-          );
+              SecurityErrorStatus.AUTH_LOGGED_OUT_TOKEN.name());
           return;
         }
         tokenService.validateToken(token);
@@ -67,8 +66,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
           CustomErrorSend.handleException(
               response,
               SecurityErrorStatus.AUTH_TOKEN_HAS_EXPIRED,
-              SecurityErrorStatus.AUTH_TOKEN_HAS_EXPIRED.name()
-          );
+              SecurityErrorStatus.AUTH_TOKEN_HAS_EXPIRED.name());
           return;
         }
         log.debug("토큰 만료지만 재발급 시도이므로 통과합니다.");

--- a/src/main/java/com/umc9th/bizscan/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/filter/JwtAuthenticationFilter.java
@@ -3,8 +3,11 @@ package com.umc9th.bizscan.global.security.filter;
 import static com.umc9th.bizscan.global.security.consts.StaticVariable.HEALTH_CHECK_ENDPOINT;
 import static com.umc9th.bizscan.global.security.consts.StaticVariable.REISSUE_ENDPOINT;
 
+import com.umc9th.bizscan.global.security.exception.CustomErrorSend;
 import com.umc9th.bizscan.global.security.exception.JwtAuthenticationException;
 import com.umc9th.bizscan.global.security.exception.JwtAuthenticationExpiredException;
+import com.umc9th.bizscan.global.security.exception.SecurityErrorStatus;
+import com.umc9th.bizscan.global.security.jwt.service.RedisService;
 import com.umc9th.bizscan.global.security.jwt.service.TokenService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -25,6 +28,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final TokenService tokenService;
+  private final RedisService redisService;
 
   @Override
   protected void doFilterInternal(
@@ -40,6 +44,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     if (token != null) {
       // 만료 케이스만 해당 필터에서 처리. 나머지는 JwtExceptionFilter 에서 처리
       try {
+        if (redisService.isBlacklisted(token)) {
+          CustomErrorSend.handleException(
+              response,
+              SecurityErrorStatus.AUTH_LOGGED_OUT_TOKEN,
+              SecurityErrorStatus.AUTH_LOGGED_OUT_TOKEN.name()
+          );
+          return;
+        }
         tokenService.validateToken(token);
         // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
         Authentication authentication = tokenService.getAuthentication(token);
@@ -51,8 +63,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             requestURI,
             authentication.getAuthorities());
       } catch (JwtAuthenticationExpiredException e) {
-        if (!requestURI.equals(REISSUE_ENDPOINT)) throw JwtAuthenticationException.TOKEN_IS_EXPIRED;
+        if (!requestURI.equals(REISSUE_ENDPOINT)) {
+          CustomErrorSend.handleException(
+              response,
+              SecurityErrorStatus.AUTH_TOKEN_HAS_EXPIRED,
+              SecurityErrorStatus.AUTH_TOKEN_HAS_EXPIRED.name()
+          );
+          return;
+        }
         log.debug("토큰 만료지만 재발급 시도이므로 통과합니다.");
+
+      } catch (JwtAuthenticationException e) {
+        SecurityErrorStatus status;
+        try {
+          status = SecurityErrorStatus.valueOf(e.getMessage());
+        } catch (Exception ex) {
+          status = SecurityErrorStatus.AUTH_INVALID_TOKEN;
+        }
+
+        CustomErrorSend.handleException(response, status, status.name());
+        return;
       }
     } else {
       if (!requestURI.equals(HEALTH_CHECK_ENDPOINT)) {

--- a/src/main/java/com/umc9th/bizscan/global/security/jwt/service/RedisService.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/jwt/service/RedisService.java
@@ -11,7 +11,9 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class RedisService {
+
   private final RedisTemplate redisTemplate;
+  private static final String BLACKLIST_PREFIX = "blacklist:";
 
   // FOR Refresh token(whiteList)
   // key-value 설정
@@ -23,7 +25,7 @@ public class RedisService {
   }
 
   public void deleteRefreshTokenByEmail(String email) {
-    String refreshToken = redisTemplate.opsForValue().get(email).toString();
+    String refreshToken = (String) redisTemplate.opsForValue().get(email);
     if (refreshToken != null) {
       redisTemplate.delete(refreshToken);
       redisTemplate.delete(email);
@@ -42,5 +44,34 @@ public class RedisService {
       token = token.substring(7);
     }
     redisTemplate.delete(token);
+  }
+
+  // AccessToken 블랙리스트 등록 (TTL: 남은 만료시간)
+  public void blacklistAccessToken(String accessToken, Duration ttl) {
+    if (accessToken == null) {
+      return;
+    }
+    if (accessToken.startsWith("Bearer ")) {
+      accessToken = accessToken.substring(7);
+    }
+
+    if (ttl == null || ttl.isZero() || ttl.isNegative()) {
+      return;
+    }
+
+    redisTemplate.opsForValue().set(BLACKLIST_PREFIX + accessToken, "logout", ttl);
+  }
+
+  // 블랙리스트 여부 확인
+  public boolean isBlacklisted(String accessToken) {
+    if (accessToken == null) {
+      return false;
+    }
+    if (accessToken.startsWith("Bearer ")) {
+      accessToken = accessToken.substring(7);
+    }
+
+    Boolean exists = redisTemplate.hasKey(BLACKLIST_PREFIX + accessToken);
+    return Boolean.TRUE.equals(exists);
   }
 }

--- a/src/main/java/com/umc9th/bizscan/global/security/jwt/service/TokenService.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/jwt/service/TokenService.java
@@ -17,7 +17,7 @@ public interface TokenService {
 
   boolean validateToken(String token);
 
-  boolean logout(String email);
+  boolean logout(String email, String accessToken);
 
   boolean existsRefreshToken(String refreshToken);
 

--- a/src/main/java/com/umc9th/bizscan/global/security/jwt/service/TokenServiceImpl.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/jwt/service/TokenServiceImpl.java
@@ -71,6 +71,10 @@ public class TokenServiceImpl implements TokenService {
 
   @Override
   public JwtToken issueTokens(String refreshToken) {
+    if (refreshToken == null) {
+      throw new GeneralException(SecurityErrorStatus.AUTH_INVALID_REFRESH_TOKEN);
+    }
+
     refreshToken = resolveToken(refreshToken);
 
     if (!validateToken(refreshToken) || !existsRefreshToken(refreshToken)) {

--- a/src/main/java/com/umc9th/bizscan/global/security/jwt/service/TokenServiceImpl.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/jwt/service/TokenServiceImpl.java
@@ -9,10 +9,18 @@ import com.umc9th.bizscan.global.security.exception.JwtAuthenticationExpiredExce
 import com.umc9th.bizscan.global.security.exception.SecurityErrorStatus;
 import com.umc9th.bizscan.global.security.jwt.dto.JwtToken;
 import com.umc9th.bizscan.global.security.jwt.dto.MemberLoginRequestDto;
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import java.security.Key;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -31,6 +39,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 public class TokenServiceImpl implements TokenService {
+
   private final Key key; // security yml 파일 생성 후 app.jwt.secret에 값 넣어주기(보안을 위해 따로 연락주세요)
   private final RedisService redisService;
   private final MemberQueryService memberQueryService;
@@ -68,10 +77,10 @@ public class TokenServiceImpl implements TokenService {
       throw new GeneralException(SecurityErrorStatus.AUTH_INVALID_REFRESH_TOKEN);
     }
 
-    redisService.deleteValue(refreshToken);
-
     Claims claims = parseClaims(refreshToken);
     String email = claims.getSubject();
+    redisService.deleteRefreshTokenByEmail(email);
+
     Member member = memberQueryService.getMemberByEmail(email);
 
     Authentication authentication =
@@ -147,7 +156,7 @@ public class TokenServiceImpl implements TokenService {
     try {
       Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
       return true;
-    } catch (SecurityException | MalformedJwtException e) {
+    } catch (SignatureException | SecurityException | MalformedJwtException e) {
       log.info("Invalid JWT Token", e);
       throw JwtAuthenticationException.INVALID_TOKEN;
     } catch (ExpiredJwtException e) {
@@ -163,9 +172,25 @@ public class TokenServiceImpl implements TokenService {
   }
 
   @Override
-  public boolean logout(String email) {
+  public boolean logout(String email, String accessToken) {
     // email 기준으로 Redis에 저장된 refreshToken 찾아서 삭제
     redisService.deleteRefreshTokenByEmail(email);
+
+    // accessToken 블랙리스트 (남은 TTL만큼)
+    if (accessToken != null) {
+      accessToken = resolveToken(accessToken);
+      try {
+        Date exp = parseExpiration(accessToken);
+        long remainingMillis = exp.getTime() - System.currentTimeMillis();
+
+        if (remainingMillis > 0) {
+          redisService.blacklistAccessToken(accessToken, Duration.ofMillis(remainingMillis));
+        }
+      } catch (Exception e) {
+        // accessToken이 이상해도 로그아웃은 성공 처리
+        log.info("logout accessToken parse failed: {}", e.getMessage());
+      }
+    }
     return true;
   }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,3 +8,4 @@ spring:
   data:
     redis:
       host: redis
+      port: 6379

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,11 @@
+ai:
+  fastapi:
+    base-url: http://localhost:8000
+  callback:
+    base-url: http://localhost:8080
+
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,11 +22,6 @@ spring:
   sql:
     init:
       mode: always
-  data:
-    redis:
-      host: localhost
-      port: 6379
-#      password: ${REDIS_PASS}
 
 naver:
   ad:


### PR DESCRIPTION
## 💡 관련 이슈
- Close #88 

## 🛠 작업 내용

- Redis 기반 토큰 관리 구조 도입
    - Redis 컨테이너 구성 (docker-compose)
    - application-local / dev 환경 분리
    - RedisConfig 설정 추가

- Refresh Token 화이트리스트 방식 적용
    - 로그인 시 Refresh Token Redis 저장
    - 재발급 시 기존 Refresh Token 삭제 후 재발급
    - 로그아웃 시 이메일 기준 Refresh Token 제거

- Access Token 블랙리스트 적용
    -   로그아웃 시 Access Token을 Redis 블랙리스트 등록 (TTL = 남은 만료시간)
    -   JwtAuthenticationFilter에서 블랙리스트 토큰 차단
    -   AUTH_LOGGED_OUT_TOKEN 예외 코드 추가

- JWT 인증 필터 개선
    - JwtAuthenticationFilter 예외 처리 정리
    - SignatureException 포함 INVALID_TOKEN 처리
    - 재발급 URI에 대해서만 만료 허용 처리

- TokenService 리팩토링
    - logout 로직 안정성 개선 (토큰 파싱 실패 시에도 로그아웃 성공 처리)
    - issueTokens 로직 개선 (이메일 기준 refresh 삭제)

## 📷 스웨거 테스트 이미지
- 로그아웃 후 동일한 Access Token으로 API 요청 시 Redis 블랙리스트 검증에 의해 차단되는 것을 확인
<img width="1080"  alt="image" src="https://github.com/user-attachments/assets/a266bb02-71a2-4b8c-91db-0fc0fac0cd28" />

- refresh로 재발급
<img width="1080" alt="image" src="https://github.com/user-attachments/assets/479a3f13-66c6-46b9-9fe5-f3df48896422" />

- 로그아웃 후 reissue 시도
<img width="1080" alt="image" src="https://github.com/user-attachments/assets/8f5fd394-3cc8-45a3-8fe4-8ad86602b7df" />

