### PR TITLE
:bug: Fix: 루트(/) 요청 시 500 대신 404 응답하도록 예외 처리 보완

### DIFF
--- a/src/main/java/com/umc9th/bizscan/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc9th/bizscan/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.reactive.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 @RequiredArgsConstructor
@@ -132,6 +133,15 @@ public class GeneralExceptionAdvice {
 
     ErrorCode code = ErrorCode.INVALID_TYPE_VALUE;
     return ResponseEntity.status(code.getStatus()).body(ApiResponse.onFailure(code, errors));
+  }
+
+  // 정적 리소스 또는 매핑되지 않은 URL을 500이 아닌 404(Not Found)로 응답하도록 처리
+  @ExceptionHandler(NoResourceFoundException.class)
+  public ResponseEntity<ApiResponse<Void>> handleNoResourceFoundException(
+      NoResourceFoundException ex) {
+
+    return ResponseEntity.status(ErrorCode.NOT_FOUND.getStatus())
+        .body(ApiResponse.onFailure(ErrorCode.NOT_FOUND, null));
   }
 
   // 그 외의 정의되지 않은 모든 예외 처리


### PR DESCRIPTION
## 💡 관련 이슈
- Close #93 

## 🛠 작업 내용
- 루트(/) 요청 시 NoResourceFoundException이 500으로 처리되던 문제 수정
- 해당 예외를 404(Not Found)로 매핑하도록 GeneralExceptionAdvice 보완
- 잘못된 500 응답 로그가 Dozzle 등 모니터링 시스템에 쌓이지 않도록 개선