### PR TITLE
:sparkles: Feat: 로그인 사용자 본인 가게 조회 API 추가

### DIFF
--- a/src/main/java/com/umc9th/bizscan/domain/store/controller/StoreController.java
+++ b/src/main/java/com/umc9th/bizscan/domain/store/controller/StoreController.java
@@ -159,6 +159,21 @@ public class StoreController {
     return ResponseEntity.ok(ApiResponse.onSuccess(SuccessCode.OK, storeService.getStore(storeId)));
   }
 
+  @Operation(summary = "내 가게 조회", description = "로그인 사용자의 Access Token 기반으로 본인 소유 가게 정보를 조회합니다.")
+  @GetMapping("/me")
+  public ResponseEntity<ApiResponse<StoreResponse>> getMyStore(
+      @Parameter(hidden = true) @AuthenticationPrincipal
+          org.springframework.security.core.userdetails.User user) {
+
+    if (user == null) {
+      throw new GeneralException(SecurityErrorStatus.AUTH_MUST_AUTHORIZED_URI);
+    }
+
+    String email = user.getUsername();
+
+    return ResponseEntity.ok(ApiResponse.onSuccess(SuccessCode.OK, storeService.getMyStore(email)));
+  }
+
   @Operation(
       summary = "가게 정보 부분 수정",
       description =

--- a/src/main/java/com/umc9th/bizscan/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/umc9th/bizscan/domain/store/repository/StoreRepository.java
@@ -1,5 +1,6 @@
 package com.umc9th.bizscan.domain.store.repository;
 
+import com.umc9th.bizscan.domain.member.entity.Member;
 import com.umc9th.bizscan.domain.store.entity.Store;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
   boolean existsByAddress(String address);
 
   boolean existsByAddressAndIdNot(String address, Long id);
+
+  Optional<Store> findByMember(Member member);
 }

--- a/src/main/java/com/umc9th/bizscan/domain/store/service/StoreService.java
+++ b/src/main/java/com/umc9th/bizscan/domain/store/service/StoreService.java
@@ -14,6 +14,8 @@ public interface StoreService {
 
   StoreResponse getStore(Long storeId);
 
+  StoreResponse getMyStore(String email);
+
   StoreResponse updateStore(Long storeId, String email, StoreUpdateRequest request);
 
   StoreResponse updateStoreTags(Long storeId, String email, List<String> tags);

--- a/src/main/java/com/umc9th/bizscan/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/umc9th/bizscan/domain/store/service/StoreServiceImpl.java
@@ -117,6 +117,28 @@ public class StoreServiceImpl implements StoreService {
   }
 
   @Override
+  @Transactional(readOnly = true)
+  public StoreResponse getMyStore(String email) {
+
+    Member member =
+        memberRepository
+            .findByEmail(email)
+            .orElseThrow(() -> new GeneralException(StoreErrorCode.MEMBER_NOT_FOUND));
+
+    Store store =
+        storeRepository
+            .findByMember(member)
+            .orElseThrow(() -> new GeneralException(StoreErrorCode.STORE_NOT_FOUND));
+
+    List<Tag> tags =
+        storeTagRepository.findAllByStoreFetchTag(store).stream().map(StoreTag::getTag).toList();
+
+    Long analysisId = analysisRepository.findLatestAnalysisIdByStoreId(store.getId()).orElse(null);
+
+    return storeMapper.toCreateResponse(store, tags, analysisId);
+  }
+
+  @Override
   public StoreResponse updateStore(Long storeId, String email, StoreUpdateRequest request) {
 
     Store store = validateStoreOwner(storeId, email);


### PR DESCRIPTION
## 💡 관련 이슈
- Close #109 

## 🛠 작업 내용
- GET /api/stores/me 엔드포인트 추가
- Member 기준 Store 조회 로직 구현