### PR TITLE
:wrench: Settings: Monitoring 설정 정리 및 로컬 포트 바인딩 적용

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -64,8 +64,10 @@ services:
   prometheus:
     image: prom/prometheus:latest
     container_name: prometheus
+    ports:
+      - "127.0.0.1:9090:9090"
     volumes:
-      - ../prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
@@ -77,6 +79,8 @@ services:
   grafana:
     image: grafana/grafana:latest
     container_name: grafana
+    ports:
+      - "127.0.0.1:3000:3000"
     volumes:
       - grafana-data:/var/lib/grafana
     environment:

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -6,3 +6,5 @@ scrape_configs:
     metrics_path: "/actuator/prometheus"
     static_configs:
       - targets: [ "bizscan-app-dev:8080" ]
+        labels:
+          application: "bizscan-app"


### PR DESCRIPTION
## 💡 관련 이슈
- Close #119 

## 🛠 작업 내용
- prometheus.yml을 docker/prometheus 경로로 이동
- Prometheus scrape 대상에 application 라벨 추가
- Prometheus(9090), Grafana(3000)를 127.0.0.1 로컬 바인딩으로 제한