### PR TITLE
♻️ Refactor: 전역 예외 처리 개선 및 Auth 응답 세분화

### DIFF
--- a/src/main/java/com/umc9th/bizscan/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc9th/bizscan/domain/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import com.umc9th.bizscan.domain.member.service.MemberQueryService;
 import com.umc9th.bizscan.global.apiPayload.ApiResponse;
 import com.umc9th.bizscan.global.apiPayload.code.ErrorCode;
 import com.umc9th.bizscan.global.apiPayload.code.SuccessCode;
+import com.umc9th.bizscan.global.apiPayload.exception.GeneralException;
 import com.umc9th.bizscan.global.config.swagger.ApiErrorCodeExamples;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,13 +18,21 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Member", description = "회원 관련 API (회원가입, 프로필 조회, 정보 수정 및 탈퇴)")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/member")
 public class MemberController {
+
   private final MemberCommandService memberCommandService;
   private final MemberQueryService memberQueryService;
 
@@ -89,8 +98,11 @@ public class MemberController {
   @GetMapping("/me")
   public ResponseEntity<ApiResponse<MemberResponseDto>> getMyInfo(Authentication authentication) {
     // JWT subject == email
-    String email = authentication.getName();
+    if (authentication == null || authentication.getName() == null) {
+      throw new GeneralException(ErrorCode.UNAUTHORIZED);
+    }
 
+    String email = authentication.getName();
     Member member = memberQueryService.getMemberByEmail(email);
 
     return ResponseEntity.ok(

--- a/src/main/java/com/umc9th/bizscan/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/umc9th/bizscan/domain/member/service/MemberCommandServiceImpl.java
@@ -5,8 +5,12 @@ import com.umc9th.bizscan.domain.member.dto.request.MemberUpdateRequestDto;
 import com.umc9th.bizscan.domain.member.entity.Member;
 import com.umc9th.bizscan.domain.member.exception.MemberException;
 import com.umc9th.bizscan.domain.member.repository.MemberRepository;
+import com.umc9th.bizscan.domain.store.entity.Store;
+import com.umc9th.bizscan.domain.store.repository.StoreRepository;
+import com.umc9th.bizscan.domain.store.repository.StoreTagRepository;
 import com.umc9th.bizscan.global.apiPayload.code.ErrorCode;
 import com.umc9th.bizscan.global.apiPayload.exception.GeneralException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -19,6 +23,8 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
   private final MemberRepository memberRepository;
   private final PasswordEncoder passwordEncoder;
+  private final StoreRepository storeRepository;
+  private final StoreTagRepository storeTagRepository;
 
   public Long registerMember(RegisterMemberDto registerMemberDto) {
 
@@ -62,6 +68,11 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     // 1. 닉네임 수정 (입력값이 있을 경우에만)
     if (dto.getNickname() != null && !dto.getNickname().isBlank()) {
+
+      if (memberRepository.existsByNickname(dto.getNickname())) {
+        throw new GeneralException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+      }
+
       member.updateNickname(dto.getNickname());
     }
 
@@ -84,12 +95,20 @@ public class MemberCommandServiceImpl implements MemberCommandService {
   }
 
   @Override
+  @Transactional
   public void deleteMember(Long memberId) {
 
     Member member =
         memberRepository
             .findById(memberId)
             .orElseThrow(() -> new GeneralException(ErrorCode.MEMBER_NOT_FOUND));
+
+    List<Store> stores = storeRepository.findAllByMember(member);
+
+    for (Store store : stores) {
+      storeTagRepository.deleteAllByStoreId(store.getId());
+      storeRepository.delete(store);
+    }
 
     memberRepository.delete(member);
   }

--- a/src/main/java/com/umc9th/bizscan/domain/store/entity/Store.java
+++ b/src/main/java/com/umc9th/bizscan/domain/store/entity/Store.java
@@ -3,7 +3,18 @@ package com.umc9th.bizscan.domain.store.entity;
 import com.umc9th.bizscan.domain.aiAnalysis.entity.Analysis;
 import com.umc9th.bizscan.domain.member.entity.Member;
 import com.umc9th.bizscan.global.entity.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,7 +34,7 @@ public class Store extends BaseEntity {
   private Long id;
 
   @OneToOne(fetch = FetchType.LAZY) // ManyToOne에서 OneToOne으로 변경
-  @JoinColumn(name = "member_id", nullable = false)
+  @JoinColumn(name = "member_id", nullable = false, unique = true)
   private Member member;
 
   @Column(nullable = false, length = 100)

--- a/src/main/java/com/umc9th/bizscan/domain/store/exception/StoreErrorCode.java
+++ b/src/main/java/com/umc9th/bizscan/domain/store/exception/StoreErrorCode.java
@@ -22,7 +22,9 @@ public enum StoreErrorCode implements BaseErrorCode {
   ADDRESS_INVALID("STORE400_1", "유효하지 않은 주소입니다. 주소를 다시 확인해주세요.", HttpStatus.BAD_REQUEST),
   ADDRESS_DUPLICATED("STORE400_2", "이미 등록된 주소입니다.", HttpStatus.BAD_REQUEST),
   INVALID_REQUEST_FORMAT("STORE400_3", "요청 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
-  INVALID_ENUM_VALUE("STORE400_4", "요청 값(enum)이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
+  INVALID_ENUM_VALUE("STORE400_4", "요청 값(enum)이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+
+  STORE_ALREADY_EXISTS("STORE409_1", "이미 가게를 보유한 사용자는 추가로 가게를 등록할 수 없습니다.", HttpStatus.CONFLICT);
 
   private final String code;
   private final String message;

--- a/src/main/java/com/umc9th/bizscan/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/umc9th/bizscan/domain/store/repository/StoreRepository.java
@@ -2,6 +2,7 @@ package com.umc9th.bizscan.domain.store.repository;
 
 import com.umc9th.bizscan.domain.member.entity.Member;
 import com.umc9th.bizscan.domain.store.entity.Store;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -14,4 +15,8 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
   boolean existsByAddressAndIdNot(String address, Long id);
 
   Optional<Store> findByMember(Member member);
+
+  List<Store> findAllByMember(Member member);
+
+  boolean existsByMember(Member member);
 }

--- a/src/main/java/com/umc9th/bizscan/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/umc9th/bizscan/domain/store/service/StoreServiceImpl.java
@@ -53,14 +53,18 @@ public class StoreServiceImpl implements StoreService {
   @Override
   public StoreResponse createStore(String email, StoreCreateRequest request) {
 
-    if (storeRepository.existsByAddress(request.getAddress())) {
-      throw new GeneralException(StoreErrorCode.ADDRESS_DUPLICATED);
-    }
-
     Member member =
         memberRepository
             .findByEmail(email)
             .orElseThrow(() -> new GeneralException(StoreErrorCode.MEMBER_NOT_FOUND));
+
+    if (storeRepository.existsByMember(member)) {
+      throw new GeneralException(StoreErrorCode.STORE_ALREADY_EXISTS);
+    }
+
+    if (storeRepository.existsByAddress(request.getAddress())) {
+      throw new GeneralException(StoreErrorCode.ADDRESS_DUPLICATED);
+    }
 
     GeoPoint geoPoint = geocode(request.getAddress());
 

--- a/src/main/java/com/umc9th/bizscan/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc9th/bizscan/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -155,6 +157,30 @@ public class GeneralExceptionAdvice {
 
     return ResponseEntity.status(errorStatus.getStatus())
         .body(ApiResponse.onFailure(errorStatus, null));
+  }
+
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public ResponseEntity<ApiResponse<Void>> handleDataIntegrityViolation(
+      DataIntegrityViolationException ex) {
+
+    String msg = "";
+    if (ex.getMostSpecificCause() != null && ex.getMostSpecificCause().getMessage() != null) {
+      msg = ex.getMostSpecificCause().getMessage();
+    }
+
+    // member table unique key name 기반 분기
+    if (msg.contains("UKmbmcqelty0fbrvxp1q58dn57t")) { // email unique
+      return ResponseEntity.status(ErrorCode.EMAIL_ALREADY_EXISTS.getStatus())
+          .body(ApiResponse.onFailure(ErrorCode.EMAIL_ALREADY_EXISTS, null));
+    }
+
+    if (msg.contains("UKhh9kg6jti4n1eoiertn2k6qsc")) { // nickname unique
+      return ResponseEntity.status(ErrorCode.NICKNAME_ALREADY_EXISTS.getStatus())
+          .body(ApiResponse.onFailure(ErrorCode.NICKNAME_ALREADY_EXISTS, null));
+    }
+
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(ApiResponse.onFailure(ErrorCode.MEMBER_ALREADY_REGISTERED, null));
   }
 
   // 그 외의 정의되지 않은 모든 예외 처리

--- a/src/main/java/com/umc9th/bizscan/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/config/SecurityConfig.java
@@ -16,9 +16,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 public class SecurityConfig {
+
   private final String[] allowUris = {
-    "/api/v1/tokens/login",
-    "/api/v1/member/register",
+    "/api/tokens/login",
+    "/api/member/register",
     "/swagger-ui/**",
     "/swagger-resources/**",
     "/v3/api-docs/**",
@@ -36,11 +37,7 @@ public class SecurityConfig {
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(
-            auth ->
-                auth
-                    // .requestMatchers(allowUris).permitAll().anyRequest().authenticated()
-                    .anyRequest()
-                    .permitAll())
+            auth -> auth.requestMatchers(allowUris).permitAll().anyRequest().authenticated())
         .formLogin(AbstractHttpConfigurer::disable)
         .exceptionHandling(
             handler ->


### PR DESCRIPTION
## 💡 관련 이슈
- Close #125 

## 🛠 작업 내용
- 전역 예외 처리 로직 개선 (GeneralExceptionAdvice)
- 인증/인가(Auth) 과정에서 발생하던 500 에러를 401/403으로 분리
- 사용자 당 가게 1개만 등록 가능하도록 정책 추가
- 회원 삭제 시 연관 Store, StoreTag 정리 로직 보완
