### PR TITLE
♻️ [REFACTOR] AccessToken을 통한 본인확인 로직 추가

### DIFF
--- a/src/main/java/com/umc9th/bizscan/domain/actionnote/controller/ActionNoteController.java
+++ b/src/main/java/com/umc9th/bizscan/domain/actionnote/controller/ActionNoteController.java
@@ -6,12 +6,16 @@ import com.umc9th.bizscan.domain.actionnote.service.ActionNoteService;
 import com.umc9th.bizscan.global.apiPayload.ApiResponse;
 import com.umc9th.bizscan.global.apiPayload.code.ErrorCode;
 import com.umc9th.bizscan.global.apiPayload.code.SuccessCode;
+import com.umc9th.bizscan.global.apiPayload.exception.GeneralException;
 import com.umc9th.bizscan.global.config.swagger.ApiErrorCodeExamples;
+import com.umc9th.bizscan.global.security.exception.SecurityErrorStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Action Note", description = "실행 노트 관련 API")
@@ -21,12 +25,21 @@ import org.springframework.web.bind.annotation.*;
 public class ActionNoteController {
   private final ActionNoteService actionNoteService;
 
-  @Operation(summary = "실행 노트 등록 API", description = "특정 실행 전략(ActionPlan)을 실행 노트에 등록합니다. ")
-  @ApiErrorCodeExamples({ErrorCode.ACTION_PLAN_NOT_FOUND, ErrorCode.ACTION_NOTE_ALREADY_EXISTS})
+  @Operation(summary = "실행 노트 등록 API", description = "특정 실행 전략(ActionPlan)을 실행 노트에 등록합니다. 본인의 실행 전략만 등록 가능합니다. 본인이 아닐 경우 AUTH403_1 에러가 발생합니다.")
+  @ApiErrorCodeExamples({ErrorCode.ACTION_PLAN_NOT_FOUND, ErrorCode.ACTION_NOTE_ALREADY_EXISTS, ErrorCode.FORBIDDEN})
   @PostMapping()
   public ApiResponse<ActionNoteResDTO.AddDTO> addActionNote(
+          @Parameter(hidden = true) @AuthenticationPrincipal
+          User user,
       @RequestBody ActionNoteReqDTO.AddDTO addDTO) {
-    return ApiResponse.onSuccess(SuccessCode.OK, actionNoteService.addActionNote(addDTO));
+      if (user == null) {
+          throw new GeneralException(
+                  SecurityErrorStatus
+                          .AUTH_MUST_AUTHORIZED_URI);
+      }
+      String email = user.getUsername();
+
+    return ApiResponse.onSuccess(SuccessCode.OK, actionNoteService.addActionNote(addDTO, email));
   }
 
   @Operation(
@@ -69,13 +82,21 @@ public class ActionNoteController {
   @Operation(
       summary = "상세 실행 전략 완료 상태 수정 API",
       description =
-          "특정 상세 실행 전략의 완료 여부를 수정합니다. 수정 시 해당 전략의 전체 진행도와 실행 전략(ActionPlan)의 완료 여부가 자동 갱신됩니다.")
-  @ApiErrorCodeExamples({ErrorCode.ACTION_DETAIL_NOT_FOUND})
+          "특정 상세 실행 전략의 완료 여부를 수정합니다. 수정 시 해당 전략의 전체 진행도와 실행 전략(ActionPlan)의 완료 여부가 자동 갱신됩니다. 본인의 상세 실행 전략만 수정 가능합니다. 본인이 아닐 경우 AUTH403_1 에러가 발생합니다.")
+  @ApiErrorCodeExamples({ErrorCode.ACTION_DETAIL_NOT_FOUND, ErrorCode.FORBIDDEN})
   @PatchMapping("")
   public ApiResponse<ActionNoteResDTO.UpdateActionDetailDTO> updateActionDetail(
+          @Parameter(hidden = true) @AuthenticationPrincipal
+          User user,
       @Parameter(description = "상세 실행 전략 ID", example = "10") @RequestParam Long actionDetailId,
       @Parameter(description = "완료 여부", example = "true") @RequestParam Boolean isCompleted) {
+      if (user == null) {
+          throw new GeneralException(
+                  SecurityErrorStatus
+                          .AUTH_MUST_AUTHORIZED_URI);
+      }
+      String email = user.getUsername();
     return ApiResponse.onSuccess(
-        SuccessCode.OK, actionNoteService.updateActionDetail(actionDetailId, isCompleted));
+        SuccessCode.OK, actionNoteService.updateActionDetail(actionDetailId, isCompleted, email));
   }
 }

--- a/src/main/java/com/umc9th/bizscan/domain/actionnote/controller/ActionNoteController.java
+++ b/src/main/java/com/umc9th/bizscan/domain/actionnote/controller/ActionNoteController.java
@@ -25,19 +25,23 @@ import org.springframework.web.bind.annotation.*;
 public class ActionNoteController {
   private final ActionNoteService actionNoteService;
 
-  @Operation(summary = "실행 노트 등록 API", description = "특정 실행 전략(ActionPlan)을 실행 노트에 등록합니다. 본인의 실행 전략만 등록 가능합니다. 본인이 아닐 경우 AUTH403_1 에러가 발생합니다.")
-  @ApiErrorCodeExamples({ErrorCode.ACTION_PLAN_NOT_FOUND, ErrorCode.ACTION_NOTE_ALREADY_EXISTS, ErrorCode.FORBIDDEN})
+  @Operation(
+      summary = "실행 노트 등록 API",
+      description =
+          "특정 실행 전략(ActionPlan)을 실행 노트에 등록합니다. 본인의 실행 전략만 등록 가능합니다. 본인이 아닐 경우 AUTH403_1 에러가 발생합니다.")
+  @ApiErrorCodeExamples({
+    ErrorCode.ACTION_PLAN_NOT_FOUND,
+    ErrorCode.ACTION_NOTE_ALREADY_EXISTS,
+    ErrorCode.FORBIDDEN
+  })
   @PostMapping()
   public ApiResponse<ActionNoteResDTO.AddDTO> addActionNote(
-          @Parameter(hidden = true) @AuthenticationPrincipal
-          User user,
+      @Parameter(hidden = true) @AuthenticationPrincipal User user,
       @RequestBody ActionNoteReqDTO.AddDTO addDTO) {
-      if (user == null) {
-          throw new GeneralException(
-                  SecurityErrorStatus
-                          .AUTH_MUST_AUTHORIZED_URI);
-      }
-      String email = user.getUsername();
+    if (user == null) {
+      throw new GeneralException(SecurityErrorStatus.AUTH_MUST_AUTHORIZED_URI);
+    }
+    String email = user.getUsername();
 
     return ApiResponse.onSuccess(SuccessCode.OK, actionNoteService.addActionNote(addDTO, email));
   }
@@ -86,16 +90,13 @@ public class ActionNoteController {
   @ApiErrorCodeExamples({ErrorCode.ACTION_DETAIL_NOT_FOUND, ErrorCode.FORBIDDEN})
   @PatchMapping("")
   public ApiResponse<ActionNoteResDTO.UpdateActionDetailDTO> updateActionDetail(
-          @Parameter(hidden = true) @AuthenticationPrincipal
-          User user,
+      @Parameter(hidden = true) @AuthenticationPrincipal User user,
       @Parameter(description = "상세 실행 전략 ID", example = "10") @RequestParam Long actionDetailId,
       @Parameter(description = "완료 여부", example = "true") @RequestParam Boolean isCompleted) {
-      if (user == null) {
-          throw new GeneralException(
-                  SecurityErrorStatus
-                          .AUTH_MUST_AUTHORIZED_URI);
-      }
-      String email = user.getUsername();
+    if (user == null) {
+      throw new GeneralException(SecurityErrorStatus.AUTH_MUST_AUTHORIZED_URI);
+    }
+    String email = user.getUsername();
     return ApiResponse.onSuccess(
         SuccessCode.OK, actionNoteService.updateActionDetail(actionDetailId, isCompleted, email));
   }

--- a/src/main/java/com/umc9th/bizscan/domain/actionnote/service/ActionNoteService.java
+++ b/src/main/java/com/umc9th/bizscan/domain/actionnote/service/ActionNoteService.java
@@ -9,6 +9,7 @@ import com.umc9th.bizscan.domain.aiAnalysis.entity.ActionDetail;
 import com.umc9th.bizscan.domain.aiAnalysis.entity.ActionPlan;
 import com.umc9th.bizscan.domain.aiAnalysis.repository.ActionDetailRepository;
 import com.umc9th.bizscan.domain.aiAnalysis.repository.ActionPlanRepository;
+import com.umc9th.bizscan.domain.member.repository.MemberRepository;
 import com.umc9th.bizscan.global.apiPayload.code.ErrorCode;
 import com.umc9th.bizscan.global.apiPayload.exception.GeneralException;
 import java.util.*;
@@ -23,13 +24,18 @@ public class ActionNoteService {
   private final ActionPlanRepository actionPlanRepository;
   private final ActionNoteRepository actionNoteRepository;
   private final ActionDetailRepository actionDetailRepository;
+  private final MemberRepository memberRepository;
 
   @Transactional
-  public ActionNoteResDTO.AddDTO addActionNote(ActionNoteReqDTO.AddDTO dto) {
-    ActionPlan actionPlan =
-        actionPlanRepository
-            .findById(dto.actionPlanId())
-            .orElseThrow(() -> new GeneralException(ErrorCode.ACTION_PLAN_NOT_FOUND));
+  public ActionNoteResDTO.AddDTO addActionNote(ActionNoteReqDTO.AddDTO dto, String email) {
+      // 존재 여부 확인 (Fetch Join으로 한 번에 가져옴)
+      ActionPlan actionPlan = actionPlanRepository.findByIdWithMember(dto.actionPlanId())
+              .orElseThrow(() -> new GeneralException(ErrorCode.ACTION_PLAN_NOT_FOUND));
+
+      // 본인 확인 (권한 검증)
+      if (!actionPlan.getAnalysis().getStore().getMember().getEmail().equals(email)) {
+          throw new GeneralException(ErrorCode.FORBIDDEN); // 혹은 ACCESS_DENIED
+      }
 
     // 중복 체크
     if (actionNoteRepository.existsByActionPlanId(dto.actionPlanId())) {
@@ -121,12 +127,17 @@ public class ActionNoteService {
 
   @Transactional
   public ActionNoteResDTO.UpdateActionDetailDTO updateActionDetail(
-      Long actionDetailId, Boolean isCompleted) {
+      Long actionDetailId, Boolean isCompleted, String email) {
     // ActionDetail 조회
-    ActionDetail actionDetail =
-        actionDetailRepository
-            .findByIdWithPlanAndNoteAndDetails(actionDetailId)
-            .orElseThrow(() -> new GeneralException(ErrorCode.ACTION_DETAIL_NOT_FOUND));
+      ActionDetail actionDetail = actionDetailRepository
+              .findByIdWithMemberAndAllRelated(actionDetailId)
+              .orElseThrow(() -> new GeneralException(ErrorCode.ACTION_DETAIL_NOT_FOUND));
+
+      // 본인 확인 (권한 검증)
+      String ownerEmail = actionDetail.getActionPlan().getAnalysis().getStore().getMember().getEmail();
+      if (!ownerEmail.equals(email)) {
+          throw new GeneralException(ErrorCode.FORBIDDEN);
+      }
 
     // 상태 업데이트
     actionDetail.updateIsCompleted(isCompleted);

--- a/src/main/java/com/umc9th/bizscan/domain/actionnote/service/ActionNoteService.java
+++ b/src/main/java/com/umc9th/bizscan/domain/actionnote/service/ActionNoteService.java
@@ -28,14 +28,16 @@ public class ActionNoteService {
 
   @Transactional
   public ActionNoteResDTO.AddDTO addActionNote(ActionNoteReqDTO.AddDTO dto, String email) {
-      // 존재 여부 확인 (Fetch Join으로 한 번에 가져옴)
-      ActionPlan actionPlan = actionPlanRepository.findByIdWithMember(dto.actionPlanId())
-              .orElseThrow(() -> new GeneralException(ErrorCode.ACTION_PLAN_NOT_FOUND));
+    // 존재 여부 확인 (Fetch Join으로 한 번에 가져옴)
+    ActionPlan actionPlan =
+        actionPlanRepository
+            .findByIdWithMember(dto.actionPlanId())
+            .orElseThrow(() -> new GeneralException(ErrorCode.ACTION_PLAN_NOT_FOUND));
 
-      // 본인 확인 (권한 검증)
-      if (!actionPlan.getAnalysis().getStore().getMember().getEmail().equals(email)) {
-          throw new GeneralException(ErrorCode.FORBIDDEN); // 혹은 ACCESS_DENIED
-      }
+    // 본인 확인 (권한 검증)
+    if (!actionPlan.getAnalysis().getStore().getMember().getEmail().equals(email)) {
+      throw new GeneralException(ErrorCode.FORBIDDEN); // 혹은 ACCESS_DENIED
+    }
 
     // 중복 체크
     if (actionNoteRepository.existsByActionPlanId(dto.actionPlanId())) {
@@ -129,15 +131,17 @@ public class ActionNoteService {
   public ActionNoteResDTO.UpdateActionDetailDTO updateActionDetail(
       Long actionDetailId, Boolean isCompleted, String email) {
     // ActionDetail 조회
-      ActionDetail actionDetail = actionDetailRepository
-              .findByIdWithMemberAndAllRelated(actionDetailId)
-              .orElseThrow(() -> new GeneralException(ErrorCode.ACTION_DETAIL_NOT_FOUND));
+    ActionDetail actionDetail =
+        actionDetailRepository
+            .findByIdWithMemberAndAllRelated(actionDetailId)
+            .orElseThrow(() -> new GeneralException(ErrorCode.ACTION_DETAIL_NOT_FOUND));
 
-      // 본인 확인 (권한 검증)
-      String ownerEmail = actionDetail.getActionPlan().getAnalysis().getStore().getMember().getEmail();
-      if (!ownerEmail.equals(email)) {
-          throw new GeneralException(ErrorCode.FORBIDDEN);
-      }
+    // 본인 확인 (권한 검증)
+    String ownerEmail =
+        actionDetail.getActionPlan().getAnalysis().getStore().getMember().getEmail();
+    if (!ownerEmail.equals(email)) {
+      throw new GeneralException(ErrorCode.FORBIDDEN);
+    }
 
     // 상태 업데이트
     actionDetail.updateIsCompleted(isCompleted);

--- a/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/controller/AiAnalysisController.java
+++ b/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/controller/AiAnalysisController.java
@@ -18,6 +18,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "AI Analysis", description = "AI 기반 SWOT 분석 및 실행 전략 추천 API")
@@ -34,7 +35,7 @@ public class AiAnalysisController {
       summary = "매장 AI 분석 요청",
       description =
           """
-            특정 매장(storeId)에 대해 AI 분석을 요청합니다.
+            특정 매장(storeId)에 대해 AI 분석을 요청합니다. 본인의 매장만 분석 가능합니다.
 
             - 분석 요청 시 비동기 방식으로 AI 서버(FastAPI)에 분석을 전달합니다.
             - 분석 요청이 성공하면 requestId를 반환합니다.
@@ -44,16 +45,21 @@ public class AiAnalysisController {
             1. 이미 분석이 완료된 경우 `ANALYSIS_ALREADY_IN_COMPLETED` 에러가 발생합니다. 재시도를 원할 경우 `retry: true`로 요청하세요.
             2. 이미 분석이 진행 중인 경우 `ANALYSIS_ALREADY_IN_PROGRESS` 에러가 발생합니다.
             """)
-  @ApiErrorCodeExamples({
+  @ApiErrorCodeExamples(value = {
     ErrorCode.STORE_NOT_FOUND,
     ErrorCode.ANALYSIS_ALREADY_IN_COMPLETED,
     ErrorCode.ANALYSIS_ALREADY_IN_PROGRESS,
-    ErrorCode.ANALYSIS_SERVER_ERROR
-  })
+    ErrorCode.ANALYSIS_SERVER_ERROR,
+          ErrorCode.ANALYSIS_FORBIDDEN
+
+  },
+          security = {SecurityErrorStatus
+                  .AUTH_MUST_AUTHORIZED_URI}
+  )
   @PostMapping
   public ApiResponse<AnalysisRequestResponse> analyze(
           @Parameter(hidden = true) @AuthenticationPrincipal
-          org.springframework.security.core.userdetails.User user,
+          User user,
       @Valid @RequestBody AnalysisReqDTO.AiAnalysisDTO request) {
 
       if (user == null) {
@@ -63,8 +69,8 @@ public class AiAnalysisController {
       }
 
       String email = user.getUsername();
-      log.info(email);
-    return ApiResponse.onSuccess(SuccessCode.OK, aiAnalysisService.analyzeStore(request));
+
+    return ApiResponse.onSuccess(SuccessCode.OK, aiAnalysisService.analyzeStore(request, email));
   }
 
   // 분석 상태 조회 (폴링용)

--- a/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/controller/AiAnalysisController.java
+++ b/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/controller/AiAnalysisController.java
@@ -45,30 +45,25 @@ public class AiAnalysisController {
             1. 이미 분석이 완료된 경우 `ANALYSIS_ALREADY_IN_COMPLETED` 에러가 발생합니다. 재시도를 원할 경우 `retry: true`로 요청하세요.
             2. 이미 분석이 진행 중인 경우 `ANALYSIS_ALREADY_IN_PROGRESS` 에러가 발생합니다.
             """)
-  @ApiErrorCodeExamples(value = {
-    ErrorCode.STORE_NOT_FOUND,
-    ErrorCode.ANALYSIS_ALREADY_IN_COMPLETED,
-    ErrorCode.ANALYSIS_ALREADY_IN_PROGRESS,
-    ErrorCode.ANALYSIS_SERVER_ERROR,
-          ErrorCode.ANALYSIS_FORBIDDEN
-
-  },
-          security = {SecurityErrorStatus
-                  .AUTH_MUST_AUTHORIZED_URI}
-  )
+  @ApiErrorCodeExamples(
+      value = {
+        ErrorCode.STORE_NOT_FOUND,
+        ErrorCode.ANALYSIS_ALREADY_IN_COMPLETED,
+        ErrorCode.ANALYSIS_ALREADY_IN_PROGRESS,
+        ErrorCode.ANALYSIS_SERVER_ERROR,
+        ErrorCode.ANALYSIS_FORBIDDEN
+      },
+      security = {SecurityErrorStatus.AUTH_MUST_AUTHORIZED_URI})
   @PostMapping
   public ApiResponse<AnalysisRequestResponse> analyze(
-          @Parameter(hidden = true) @AuthenticationPrincipal
-          User user,
+      @Parameter(hidden = true) @AuthenticationPrincipal User user,
       @Valid @RequestBody AnalysisReqDTO.AiAnalysisDTO request) {
 
-      if (user == null) {
-          throw new GeneralException(
-                  SecurityErrorStatus
-                          .AUTH_MUST_AUTHORIZED_URI);
-      }
+    if (user == null) {
+      throw new GeneralException(SecurityErrorStatus.AUTH_MUST_AUTHORIZED_URI);
+    }
 
-      String email = user.getUsername();
+    String email = user.getUsername();
 
     return ApiResponse.onSuccess(SuccessCode.OK, aiAnalysisService.analyzeStore(request, email));
   }

--- a/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/controller/AiAnalysisController.java
+++ b/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/controller/AiAnalysisController.java
@@ -7,19 +7,24 @@ import com.umc9th.bizscan.domain.aiAnalysis.service.AiAnalysisService;
 import com.umc9th.bizscan.global.apiPayload.ApiResponse;
 import com.umc9th.bizscan.global.apiPayload.code.ErrorCode;
 import com.umc9th.bizscan.global.apiPayload.code.SuccessCode;
+import com.umc9th.bizscan.global.apiPayload.exception.GeneralException;
 import com.umc9th.bizscan.global.config.swagger.ApiErrorCodeExamples;
+import com.umc9th.bizscan.global.security.exception.SecurityErrorStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "AI Analysis", description = "AI 기반 SWOT 분석 및 실행 전략 추천 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/analysis")
+@Slf4j
 public class AiAnalysisController {
 
   private final AiAnalysisService aiAnalysisService;
@@ -47,7 +52,18 @@ public class AiAnalysisController {
   })
   @PostMapping
   public ApiResponse<AnalysisRequestResponse> analyze(
+          @Parameter(hidden = true) @AuthenticationPrincipal
+          org.springframework.security.core.userdetails.User user,
       @Valid @RequestBody AnalysisReqDTO.AiAnalysisDTO request) {
+
+      if (user == null) {
+          throw new GeneralException(
+                  SecurityErrorStatus
+                          .AUTH_MUST_AUTHORIZED_URI);
+      }
+
+      String email = user.getUsername();
+      log.info(email);
     return ApiResponse.onSuccess(SuccessCode.OK, aiAnalysisService.analyzeStore(request));
   }
 

--- a/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/repository/ActionDetailRepository.java
+++ b/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/repository/ActionDetailRepository.java
@@ -24,15 +24,19 @@ public interface ActionDetailRepository extends JpaRepository<ActionDetail, Long
           "WHERE ad.id = :id")
   Optional<ActionDetail> findByIdWithPlanAndNoteAndDetails(@Param("id") Long id);
 
-    @Query("SELECT ad FROM ActionDetail ad " +
-            "JOIN FETCH ad.actionPlan ap " +
-            "JOIN FETCH ap.details " +             // 진행도 계산용
-            "LEFT JOIN FETCH ap.actionNote " +      // 상태 동기화용
-            "JOIN FETCH ap.analysis a " +           // 본인 확인용
-            "JOIN FETCH a.store s " +               // 본인 확인용
-            "JOIN FETCH s.member m " +              // 본인 확인용
-            "WHERE ad.id = :id")
-    Optional<ActionDetail> findByIdWithMemberAndAllRelated(@Param("id") Long id);
-
-
+  @Query(
+      "SELECT ad FROM ActionDetail ad "
+          + "JOIN FETCH ad.actionPlan ap "
+          + "JOIN FETCH ap.details "
+          + // 진행도 계산용
+          "LEFT JOIN FETCH ap.actionNote "
+          + // 상태 동기화용
+          "JOIN FETCH ap.analysis a "
+          + // 본인 확인용
+          "JOIN FETCH a.store s "
+          + // 본인 확인용
+          "JOIN FETCH s.member m "
+          + // 본인 확인용
+          "WHERE ad.id = :id")
+  Optional<ActionDetail> findByIdWithMemberAndAllRelated(@Param("id") Long id);
 }

--- a/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/repository/ActionDetailRepository.java
+++ b/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/repository/ActionDetailRepository.java
@@ -23,4 +23,16 @@ public interface ActionDetailRepository extends JpaRepository<ActionDetail, Long
           + // 진행도 계산을 위해 모든 상세 미션들을 함께 로드
           "WHERE ad.id = :id")
   Optional<ActionDetail> findByIdWithPlanAndNoteAndDetails(@Param("id") Long id);
+
+    @Query("SELECT ad FROM ActionDetail ad " +
+            "JOIN FETCH ad.actionPlan ap " +
+            "JOIN FETCH ap.details " +             // 진행도 계산용
+            "LEFT JOIN FETCH ap.actionNote " +      // 상태 동기화용
+            "JOIN FETCH ap.analysis a " +           // 본인 확인용
+            "JOIN FETCH a.store s " +               // 본인 확인용
+            "JOIN FETCH s.member m " +              // 본인 확인용
+            "WHERE ad.id = :id")
+    Optional<ActionDetail> findByIdWithMemberAndAllRelated(@Param("id") Long id);
+
+
 }

--- a/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/repository/ActionPlanRepository.java
+++ b/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/repository/ActionPlanRepository.java
@@ -28,22 +28,22 @@ public interface ActionPlanRepository extends JpaRepository<ActionPlan, Long> {
       @Param("storeId") Long storeId, @Param("isCompleted") Boolean isCompleted);
 
   // Tags만 FetchJoin
-//  @Query("SELECT ap FROM ActionPlan ap LEFT JOIN FETCH ap.tags WHERE ap.id = :id")
-//  Optional<ActionPlan> findByIdWithTags(@Param("id") Long id);
+  //  @Query("SELECT ap FROM ActionPlan ap LEFT JOIN FETCH ap.tags WHERE ap.id = :id")
+  //  Optional<ActionPlan> findByIdWithTags(@Param("id") Long id);
 
   // Details만 FetchJoin
-//  @Query(
-//      "SELECT ap FROM ActionPlan ap "
-//          + "JOIN FETCH ap.details ad "
-//          + "WHERE ap.id = :id "
-//          + "ORDER BY ad.step ASC")
-//  Optional<ActionPlan> findByIdWithDetails(@Param("id") Long id);
+  //  @Query(
+  //      "SELECT ap FROM ActionPlan ap "
+  //          + "JOIN FETCH ap.details ad "
+  //          + "WHERE ap.id = :id "
+  //          + "ORDER BY ad.step ASC")
+  //  Optional<ActionPlan> findByIdWithDetails(@Param("id") Long id);
 
-    @Query("SELECT ap FROM ActionPlan ap " +
-            "JOIN FETCH ap.analysis a " +
-            "JOIN FETCH a.store s " +
-            "JOIN FETCH s.member m " +
-            "WHERE ap.id = :id")
-    Optional<ActionPlan> findByIdWithMember(@Param("id") Long id);
-
+  @Query(
+      "SELECT ap FROM ActionPlan ap "
+          + "JOIN FETCH ap.analysis a "
+          + "JOIN FETCH a.store s "
+          + "JOIN FETCH s.member m "
+          + "WHERE ap.id = :id")
+  Optional<ActionPlan> findByIdWithMember(@Param("id") Long id);
 }

--- a/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/repository/ActionPlanRepository.java
+++ b/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/repository/ActionPlanRepository.java
@@ -28,14 +28,22 @@ public interface ActionPlanRepository extends JpaRepository<ActionPlan, Long> {
       @Param("storeId") Long storeId, @Param("isCompleted") Boolean isCompleted);
 
   // Tags만 FetchJoin
-  @Query("SELECT ap FROM ActionPlan ap LEFT JOIN FETCH ap.tags WHERE ap.id = :id")
-  Optional<ActionPlan> findByIdWithTags(@Param("id") Long id);
+//  @Query("SELECT ap FROM ActionPlan ap LEFT JOIN FETCH ap.tags WHERE ap.id = :id")
+//  Optional<ActionPlan> findByIdWithTags(@Param("id") Long id);
 
   // Details만 FetchJoin
-  @Query(
-      "SELECT ap FROM ActionPlan ap "
-          + "JOIN FETCH ap.details ad "
-          + "WHERE ap.id = :id "
-          + "ORDER BY ad.step ASC")
-  Optional<ActionPlan> findByIdWithDetails(@Param("id") Long id);
+//  @Query(
+//      "SELECT ap FROM ActionPlan ap "
+//          + "JOIN FETCH ap.details ad "
+//          + "WHERE ap.id = :id "
+//          + "ORDER BY ad.step ASC")
+//  Optional<ActionPlan> findByIdWithDetails(@Param("id") Long id);
+
+    @Query("SELECT ap FROM ActionPlan ap " +
+            "JOIN FETCH ap.analysis a " +
+            "JOIN FETCH a.store s " +
+            "JOIN FETCH s.member m " +
+            "WHERE ap.id = :id")
+    Optional<ActionPlan> findByIdWithMember(@Param("id") Long id);
+
 }

--- a/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/service/AiAnalysisService.java
+++ b/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/service/AiAnalysisService.java
@@ -54,7 +54,7 @@ public class AiAnalysisService {
 
   /** AI 분석 요청 (프론트에서 최초 1회 호출) requestId 반환 → 프론트에서 폴링 */
   @Transactional
-  public AnalysisRequestResponse analyzeStore(AnalysisReqDTO.AiAnalysisDTO dto) {
+  public AnalysisRequestResponse analyzeStore(AnalysisReqDTO.AiAnalysisDTO dto, String email) {
     Long storeId = dto.storeId();
     Boolean retry = dto.retry();
 
@@ -63,6 +63,11 @@ public class AiAnalysisService {
         storeRepository
             .findById(storeId)
             .orElseThrow(() -> new GeneralException(ErrorCode.STORE_NOT_FOUND));
+      // 매장의 소유자 이메일과 현재 요청자의 이메일을 비교 (Store 엔티티에 Member 연관관계가 있다고 가정)
+      if (!store.getMember().getEmail().equals(email)) {
+          // 본인 매장이 아닌 경우 권한 에러 발생
+          throw new GeneralException(ErrorCode.ANALYSIS_FORBIDDEN);
+      }
 
     // 재시도 로직: 기존 분석 이력 체크 및 실패 시 삭제
     analysisRepository
@@ -280,4 +285,5 @@ public class AiAnalysisService {
         .tags(tagInfos)
         .build();
   }
+
 }

--- a/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/service/AiAnalysisService.java
+++ b/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/service/AiAnalysisService.java
@@ -74,8 +74,8 @@ public class AiAnalysisService {
                   analysisRequestRepository.findByAnalysis(existingAnalysis).orElse(null);
 
               if (existingRequest != null) {
-                // 상태가 FAILED인 경우 || retry=True 삭제 후 재시도
-                if (existingRequest.getStatus() == AnalysisStatus.FAILED || retry) {
+                // 상태가 FAILED인 경우 || (완료 AND retry=True) 삭제 후 재시도
+                if (existingRequest.getStatus() == AnalysisStatus.FAILED || (existingRequest.getStatus() == AnalysisStatus.COMPLETED && retry)) {
                   // @OnDelete를 활용한 Bulk삭제
                   // JPA의 delete()는 @OnDelete와 상관없이 엔티티를 하나씩 조회 후 삭제하므로 N+1 발생
                   // @Query로 DB에 Delete 쿼리를 직접 날려 DB 레벨에서 단일 쿼리로 연쇄 삭제를 수행함

--- a/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/service/AiAnalysisService.java
+++ b/src/main/java/com/umc9th/bizscan/domain/aiAnalysis/service/AiAnalysisService.java
@@ -63,11 +63,11 @@ public class AiAnalysisService {
         storeRepository
             .findById(storeId)
             .orElseThrow(() -> new GeneralException(ErrorCode.STORE_NOT_FOUND));
-      // 매장의 소유자 이메일과 현재 요청자의 이메일을 비교 (Store 엔티티에 Member 연관관계가 있다고 가정)
-      if (!store.getMember().getEmail().equals(email)) {
-          // 본인 매장이 아닌 경우 권한 에러 발생
-          throw new GeneralException(ErrorCode.ANALYSIS_FORBIDDEN);
-      }
+    // 매장의 소유자 이메일과 현재 요청자의 이메일을 비교 (Store 엔티티에 Member 연관관계가 있다고 가정)
+    if (!store.getMember().getEmail().equals(email)) {
+      // 본인 매장이 아닌 경우 권한 에러 발생
+      throw new GeneralException(ErrorCode.ANALYSIS_FORBIDDEN);
+    }
 
     // 재시도 로직: 기존 분석 이력 체크 및 실패 시 삭제
     analysisRepository
@@ -80,7 +80,8 @@ public class AiAnalysisService {
 
               if (existingRequest != null) {
                 // 상태가 FAILED인 경우 || (완료 AND retry=True) 삭제 후 재시도
-                if (existingRequest.getStatus() == AnalysisStatus.FAILED || (existingRequest.getStatus() == AnalysisStatus.COMPLETED && retry)) {
+                if (existingRequest.getStatus() == AnalysisStatus.FAILED
+                    || (existingRequest.getStatus() == AnalysisStatus.COMPLETED && retry)) {
                   // @OnDelete를 활용한 Bulk삭제
                   // JPA의 delete()는 @OnDelete와 상관없이 엔티티를 하나씩 조회 후 삭제하므로 N+1 발생
                   // @Query로 DB에 Delete 쿼리를 직접 날려 DB 레벨에서 단일 쿼리로 연쇄 삭제를 수행함
@@ -285,5 +286,4 @@ public class AiAnalysisService {
         .tags(tagInfos)
         .build();
   }
-
 }

--- a/src/main/java/com/umc9th/bizscan/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc9th/bizscan/domain/member/controller/MemberController.java
@@ -9,13 +9,18 @@ import com.umc9th.bizscan.domain.member.service.MemberQueryService;
 import com.umc9th.bizscan.global.apiPayload.ApiResponse;
 import com.umc9th.bizscan.global.apiPayload.code.ErrorCode;
 import com.umc9th.bizscan.global.apiPayload.code.SuccessCode;
+import com.umc9th.bizscan.global.apiPayload.exception.GeneralException;
 import com.umc9th.bizscan.global.config.swagger.ApiErrorCodeExamples;
+import com.umc9th.bizscan.global.security.exception.SecurityErrorStatus;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Member", description = "회원 관련 API (회원가입, 프로필 조회, 정보 수정 및 탈퇴)")
@@ -62,15 +67,27 @@ public class MemberController {
   //  }
 
   @PatchMapping("/{memberId}")
-  @Operation(summary = "회원 정보 수정", description = "회원 닉네임 및 비밀번호를 수정합니다.")
-  @ApiErrorCodeExamples({
+  @Operation(summary = "회원 정보 수정", description = "회원 닉네임 및 비밀번호를 수정합니다. 본인의 정보만 수정 가능합니다. 본인이 아닐 경우 AUTH403_1 에러가 발생합니다.")
+  @ApiErrorCodeExamples(value = {
     ErrorCode.MEMBER_NOT_FOUND,
     ErrorCode.INVALID_PASSWORD,
-    ErrorCode.SAME_AS_OLD_PASSWORD
-  })
+    ErrorCode.SAME_AS_OLD_PASSWORD,
+          ErrorCode.FORBIDDEN
+  }, security = {SecurityErrorStatus
+          .AUTH_MUST_AUTHORIZED_URI}
+  )
   public ResponseEntity<ApiResponse<Void>> updateMember(
+          @Parameter(hidden = true) @AuthenticationPrincipal
+          User user,
       @PathVariable Long memberId, @RequestBody @Valid MemberUpdateRequestDto dto) {
-    memberCommandService.updateMember(memberId, dto);
+      if (user == null) {
+          throw new GeneralException(
+                  SecurityErrorStatus
+                          .AUTH_MUST_AUTHORIZED_URI);
+      }
+
+      String email = user.getUsername();
+    memberCommandService.updateMember(memberId, dto, email);
 
     return ResponseEntity.ok(ApiResponse.onSuccess(SuccessCode.MEMBER_UPDATE_SUCCESS, null));
   }

--- a/src/main/java/com/umc9th/bizscan/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc9th/bizscan/domain/member/controller/MemberController.java
@@ -67,26 +67,26 @@ public class MemberController {
   //  }
 
   @PatchMapping("/{memberId}")
-  @Operation(summary = "회원 정보 수정", description = "회원 닉네임 및 비밀번호를 수정합니다. 본인의 정보만 수정 가능합니다. 본인이 아닐 경우 AUTH403_1 에러가 발생합니다.")
-  @ApiErrorCodeExamples(value = {
-    ErrorCode.MEMBER_NOT_FOUND,
-    ErrorCode.INVALID_PASSWORD,
-    ErrorCode.SAME_AS_OLD_PASSWORD,
-          ErrorCode.FORBIDDEN
-  }, security = {SecurityErrorStatus
-          .AUTH_MUST_AUTHORIZED_URI}
-  )
+  @Operation(
+      summary = "회원 정보 수정",
+      description = "회원 닉네임 및 비밀번호를 수정합니다. 본인의 정보만 수정 가능합니다. 본인이 아닐 경우 AUTH403_1 에러가 발생합니다.")
+  @ApiErrorCodeExamples(
+      value = {
+        ErrorCode.MEMBER_NOT_FOUND,
+        ErrorCode.INVALID_PASSWORD,
+        ErrorCode.SAME_AS_OLD_PASSWORD,
+        ErrorCode.FORBIDDEN
+      },
+      security = {SecurityErrorStatus.AUTH_MUST_AUTHORIZED_URI})
   public ResponseEntity<ApiResponse<Void>> updateMember(
-          @Parameter(hidden = true) @AuthenticationPrincipal
-          User user,
-      @PathVariable Long memberId, @RequestBody @Valid MemberUpdateRequestDto dto) {
-      if (user == null) {
-          throw new GeneralException(
-                  SecurityErrorStatus
-                          .AUTH_MUST_AUTHORIZED_URI);
-      }
+      @Parameter(hidden = true) @AuthenticationPrincipal User user,
+      @PathVariable Long memberId,
+      @RequestBody @Valid MemberUpdateRequestDto dto) {
+    if (user == null) {
+      throw new GeneralException(SecurityErrorStatus.AUTH_MUST_AUTHORIZED_URI);
+    }
 
-      String email = user.getUsername();
+    String email = user.getUsername();
     memberCommandService.updateMember(memberId, dto, email);
 
     return ResponseEntity.ok(ApiResponse.onSuccess(SuccessCode.MEMBER_UPDATE_SUCCESS, null));

--- a/src/main/java/com/umc9th/bizscan/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/umc9th/bizscan/domain/member/service/MemberCommandService.java
@@ -6,7 +6,7 @@ import com.umc9th.bizscan.domain.member.dto.request.MemberUpdateRequestDto;
 public interface MemberCommandService {
   Long registerMember(RegisterMemberDto registerMemberDto);
 
-  void updateMember(Long memberId, MemberUpdateRequestDto dto);
+  void updateMember(Long memberId, MemberUpdateRequestDto dto, String currentUserEmail);
 
   void deleteMember(Long memberId);
 }

--- a/src/main/java/com/umc9th/bizscan/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/umc9th/bizscan/domain/member/service/MemberCommandServiceImpl.java
@@ -53,12 +53,17 @@ public class MemberCommandServiceImpl implements MemberCommandService {
   }
 
   @Override
-  public void updateMember(Long memberId, MemberUpdateRequestDto dto) {
+  public void updateMember(Long memberId, MemberUpdateRequestDto dto, String currentUserEmail) {
     // 회원 조회
     Member member =
         memberRepository
             .findById(memberId)
             .orElseThrow(() -> new GeneralException(ErrorCode.MEMBER_NOT_FOUND));
+
+      // 현재 로그인한 사용자의 이메일과 수정하려는 회원의 이메일이 일치하는지 확인
+      if (!member.getEmail().equals(currentUserEmail)) {
+          throw new GeneralException(ErrorCode.FORBIDDEN);
+      }
 
     // 1. 닉네임 수정 (입력값이 있을 경우에만)
     if (dto.getNickname() != null && !dto.getNickname().isBlank()) {

--- a/src/main/java/com/umc9th/bizscan/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/umc9th/bizscan/domain/member/service/MemberCommandServiceImpl.java
@@ -60,10 +60,10 @@ public class MemberCommandServiceImpl implements MemberCommandService {
             .findById(memberId)
             .orElseThrow(() -> new GeneralException(ErrorCode.MEMBER_NOT_FOUND));
 
-      // 현재 로그인한 사용자의 이메일과 수정하려는 회원의 이메일이 일치하는지 확인
-      if (!member.getEmail().equals(currentUserEmail)) {
-          throw new GeneralException(ErrorCode.FORBIDDEN);
-      }
+    // 현재 로그인한 사용자의 이메일과 수정하려는 회원의 이메일이 일치하는지 확인
+    if (!member.getEmail().equals(currentUserEmail)) {
+      throw new GeneralException(ErrorCode.FORBIDDEN);
+    }
 
     // 1. 닉네임 수정 (입력값이 있을 경우에만)
     if (dto.getNickname() != null && !dto.getNickname().isBlank()) {

--- a/src/main/java/com/umc9th/bizscan/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/umc9th/bizscan/global/apiPayload/code/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode implements BaseErrorCode {
 
   // JWT
   UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH401_1", "인증이 필요합니다."),
-  FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH403_1", "요청이 거부되었습니다."),
+  FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH403_1", "해당 리소스에 접근할 권한이 없습니다."),
   EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "AUTH401_2", "만료된 JWT 토큰입니다."),
   UNSUPPORTED_JWT(HttpStatus.UNAUTHORIZED, "AUTH401_3", "지원되지 않는 JWT 토큰입니다."),
   SIGNATURE_INVALID_JWT(HttpStatus.UNAUTHORIZED, "AUTH401_4", "유효하지 않은 JWT 시그니처입니다."),
@@ -45,6 +45,7 @@ public enum ErrorCode implements BaseErrorCode {
   ANALYSIS_ALREADY_IN_COMPLETED(HttpStatus.BAD_REQUEST, "ANALYSIS400_1", "이미 완료된 분석 결과가 존재합니다."),
   ANALYSIS_SERVER_ERROR(
       HttpStatus.INTERNAL_SERVER_ERROR, "ANALYSIS500_1", "AI 분석 서버와의 통신 중 오류가 발생했습니다."),
+    ANALYSIS_FORBIDDEN(HttpStatus.FORBIDDEN, "ANALYSIS403_1", "가게 소유자만 분석 요청이 가능합니다."),
 
   // Store
   STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE404_1", "해당 매장을 찾을 수 없습니다."),

--- a/src/main/java/com/umc9th/bizscan/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/umc9th/bizscan/global/apiPayload/code/ErrorCode.java
@@ -45,7 +45,7 @@ public enum ErrorCode implements BaseErrorCode {
   ANALYSIS_ALREADY_IN_COMPLETED(HttpStatus.BAD_REQUEST, "ANALYSIS400_1", "이미 완료된 분석 결과가 존재합니다."),
   ANALYSIS_SERVER_ERROR(
       HttpStatus.INTERNAL_SERVER_ERROR, "ANALYSIS500_1", "AI 분석 서버와의 통신 중 오류가 발생했습니다."),
-    ANALYSIS_FORBIDDEN(HttpStatus.FORBIDDEN, "ANALYSIS403_1", "가게 소유자만 분석 요청이 가능합니다."),
+  ANALYSIS_FORBIDDEN(HttpStatus.FORBIDDEN, "ANALYSIS403_1", "가게 소유자만 분석 요청이 가능합니다."),
 
   // Store
   STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE404_1", "해당 매장을 찾을 수 없습니다."),

--- a/src/main/java/com/umc9th/bizscan/global/security/controller/TokenApiController.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/controller/TokenApiController.java
@@ -11,6 +11,7 @@ import com.umc9th.bizscan.global.security.jwt.dto.JwtToken;
 import com.umc9th.bizscan.global.security.jwt.dto.MemberLoginRequestDto;
 import com.umc9th.bizscan.global.security.jwt.service.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -74,7 +75,7 @@ public class TokenApiController {
       })
   @PostMapping("/reissue")
   public ResponseEntity<ApiResponse<AccessTokenResponse>> reissue(
-      @CookieValue(value = "refreshToken", required = false) String refreshToken,
+          @Parameter(hidden = true) @CookieValue(value = "refreshToken", required = false) String refreshToken,
       HttpServletResponse response) {
     JwtToken token = tokenService.issueTokens(refreshToken);
 
@@ -93,8 +94,8 @@ public class TokenApiController {
       })
   @PostMapping("/logout")
   public ApiResponse<Void> logout(
-      @AuthenticationPrincipal User user,
-      @RequestHeader(value = "Authorization", required = false) String authorization,
+           @AuthenticationPrincipal User user,
+           @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = false) String authorization,
       HttpServletResponse response) {
 
     tokenService.logout(user.getUsername(), authorization);

--- a/src/main/java/com/umc9th/bizscan/global/security/controller/TokenApiController.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/controller/TokenApiController.java
@@ -75,7 +75,8 @@ public class TokenApiController {
       })
   @PostMapping("/reissue")
   public ResponseEntity<ApiResponse<AccessTokenResponse>> reissue(
-          @Parameter(hidden = true) @CookieValue(value = "refreshToken", required = false) String refreshToken,
+      @Parameter(hidden = true) @CookieValue(value = "refreshToken", required = false)
+          String refreshToken,
       HttpServletResponse response) {
     JwtToken token = tokenService.issueTokens(refreshToken);
 
@@ -94,8 +95,9 @@ public class TokenApiController {
       })
   @PostMapping("/logout")
   public ApiResponse<Void> logout(
-           @AuthenticationPrincipal User user,
-           @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = false) String authorization,
+      @AuthenticationPrincipal User user,
+      @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = false)
+          String authorization,
       HttpServletResponse response) {
 
     tokenService.logout(user.getUsername(), authorization);


### PR DESCRIPTION
## 💡 관련 이슈
- Close #144 

## 🛠 작업 내용
- 분석 완료 && retry=true 일때만 재시도 가능하도록 변경
- POST /api/analysis, PATCH /api/member/{memberId}, POST /api/v1/action-notes, PATCH /api/v1/action-notes 본인 인증 로직 추가
- 토큰 재발급, 로그아웃 Swagger Parameter hidden처리