### PR TITLE
:bug: Fix: /actuator/** 경로를 Security 및 JWT 필터에서 제외하여 Prometheus 수집 오류 해결

### DIFF
--- a/src/main/java/com/umc9th/bizscan/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 public class SecurityConfig {
+
   private final String[] allowUris = {
     "/api/tokens/login",
     "/api/members/register",
@@ -29,6 +30,7 @@ public class SecurityConfig {
     "/swagger-ui/**",
     "/swagger-resources/**",
     "/v3/api-docs/**",
+    "/actuator/**",
   };
 
   @Bean

--- a/src/main/java/com/umc9th/bizscan/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/filter/JwtAuthenticationFilter.java
@@ -91,6 +91,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     filterChain.doFilter(request, response);
   }
 
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    String path = request.getRequestURI();
+    return path.startsWith("/actuator");
+  }
+
   private String resolveToken(HttpServletRequest request) {
     String bearerToken = request.getHeader("Authorization");
 

--- a/src/main/java/com/umc9th/bizscan/global/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/umc9th/bizscan/global/security/filter/JwtExceptionFilter.java
@@ -17,6 +17,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 @Component
 public class JwtExceptionFilter extends OncePerRequestFilter {
+
   @Override
   protected void doFilterInternal(
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -34,5 +35,10 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
       CustomErrorSend.handleException(
           response, SecurityErrorStatus.INTERNAL_SECURITY_ERROR, e.getMessage());
     }
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    return request.getRequestURI().startsWith("/actuator");
   }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- Close #147 

## 🛠 작업 내용

- Actuator(/actuator/**) 경로에 대한 별도 SecurityFilterChain 분리 및 permitAll 설정
- /actuator/** 요청을 JwtAuthenticationFilter, JwtExceptionFilter에서 제외 처리